### PR TITLE
Add more profile options

### DIFF
--- a/app.js
+++ b/app.js
@@ -96,6 +96,14 @@ async function fetchProfile() {
 }
 
 async function saveProfile() {
+  appData.profile.age = parseInt(document.getElementById('age').value, 10) || 0;
+  appData.profile.location = document.getElementById('location').value;
+  appData.profile.job = document.getElementById('job').value;
+  appData.profile.company = document.getElementById('company').value;
+  appData.profile.language = document.getElementById('language').value;
+  appData.profile.experience = parseInt(document.getElementById('experience').value, 10) || 0;
+  appData.profile.industry = document.getElementById('industry').value;
+  appData.profile.education = document.getElementById('education').value;
   try {
     const response = await fetch(`${API_BASE_URL}/profile`, {
       method: 'POST',
@@ -356,7 +364,11 @@ function loadProfile() {
   document.getElementById('location').value = appData.profile.location;
   document.getElementById('job').value = appData.profile.job;
   document.getElementById('company').value = appData.profile.company;
-  
+  document.getElementById('language').value = appData.profile.language;
+  document.getElementById('experience').value = appData.profile.experience;
+  document.getElementById('industry').value = appData.profile.industry;
+  document.getElementById('education').value = appData.profile.education;
+
   renderInterests();
 }
 
@@ -619,9 +631,9 @@ function generateNewsletterContent() {
     
     <div class="newsletter-section">
       <h3>🤖 Resumen de IA</h3>
-      <p>Este briefing ha sido personalizado para <strong>${appData.profile.job}</strong> de <strong>${appData.profile.age} años</strong> 
-      en <strong>${appData.profile.location}</strong>. Se han filtrado <strong>${appData.sampleNews.length}</strong> noticias, 
-      seleccionando <strong>${relevantNews.length}</strong> con alta relevancia para tus intereses en 
+      <p>Este briefing ha sido personalizado para <strong>${appData.profile.job}</strong> de <strong>${appData.profile.age} años</strong>
+      en <strong>${appData.profile.location}</strong> (<strong>${appData.profile.language}</strong>), con <strong>${appData.profile.experience}</strong> años de experiencia en <strong>${appData.profile.industry}</strong> y formación en <strong>${appData.profile.education}</strong>. Se han filtrado <strong>${appData.sampleNews.length}</strong> noticias,
+      seleccionando <strong>${relevantNews.length}</strong> con alta relevancia para tus intereses en
       <strong>${appData.profile.interests.slice(0, 3).join(', ')}</strong> y más.</p>
     </div>
   `;

--- a/index.html
+++ b/index.html
@@ -128,6 +128,22 @@
                                         <label class="form-label">Empresa</label>
                                         <input type="text" class="form-control" id="company" value="Empresa tecnológica alemana">
                                     </div>
+                                    <div class="form-group">
+                                        <label class="form-label">Idioma preferido</label>
+                                        <input type="text" class="form-control" id="language" value="Español">
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label">Años de experiencia</label>
+                                        <input type="number" class="form-control" id="experience" value="5">
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label">Sector o industria</label>
+                                        <input type="text" class="form-control" id="industry" value="Tecnología">
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label">Nivel de estudios</label>
+                                        <input type="text" class="form-control" id="education" value="Máster en IA">
+                                    </div>
                                 </form>
                             </div>
                         </div>

--- a/server.js
+++ b/server.js
@@ -25,6 +25,10 @@ let userProfile = {
     location: "Barcelona",
     job: "Analista de datos",
     company: "Empresa tecnológica alemana",
+    language: "Español",
+    experience: 5,
+    industry: "Tecnología",
+    education: "Máster en IA",
     interests: ["nuevas leyes", "productos digitales", "software", "inteligencia artificial", "conflictos geopolíticos", "inversiones personales"],
     notInterested: ["deportes", "farándula", "casamientos", "rondas de inversión", "adquisiciones empresariales", "acuerdos internacionales sin efecto en España"]
 };
@@ -108,6 +112,8 @@ function generateNewsletterHTML(news) {
     const recap = `
       <div style="margin-bottom:18px;">
         <strong>Profile:</strong> ${userProfile.job}, ${userProfile.age} years old, ${userProfile.location}, ${userProfile.company}<br>
+        <strong>Language:</strong> ${userProfile.language} &nbsp;|&nbsp; <strong>Experience:</strong> ${userProfile.experience} años<br>
+        <strong>Industry:</strong> ${userProfile.industry} &nbsp;|&nbsp; <strong>Education:</strong> ${userProfile.education}<br>
         <strong>Interests:</strong> ${userProfile.interests.join(', ')}<br>
         <strong>Not interested in:</strong> ${userProfile.notInterested.join(', ')}<br>
         <strong>Filters:</strong> Relevance ≥ 60%
@@ -157,6 +163,10 @@ Eres un asistente experto en personalización de noticias. Analiza la siguiente 
 Edad: ${userProfile.age}
 Ubicación: ${userProfile.location}
 Trabajo: ${userProfile.job}
+Idioma: ${userProfile.language}
+Años de experiencia: ${userProfile.experience}
+Industria: ${userProfile.industry}
+Formación: ${userProfile.education}
 Intereses: ${userProfile.interests.join(', ')}
 No le interesa: ${userProfile.notInterested.join(', ')}
 Título: ${news.title}


### PR DESCRIPTION
## Summary
- expand profile form with industry and education fields
- load/save industry and education in the web app
- include new profile info in newsletter and relevance analysis

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68400688dca8832ab75db6c53559ceda